### PR TITLE
feat(operators): scroll to top of operator container on each route change

### DIFF
--- a/src/app/operators/components/operator/operator.component.ts
+++ b/src/app/operators/components/operator/operator.component.ts
@@ -41,6 +41,7 @@ export class OperatorComponent implements OnInit {
       .subscribe((name: string) => {
         if (this.operatorsMap.has(name)) {
           this.operator = this.operatorsMap.get(name);
+          this.scrollToTop();
         } else {
           this.notfound();
           return;
@@ -52,6 +53,14 @@ export class OperatorComponent implements OnInit {
             : ''
         });
       });
+  }
+
+  scrollToTop() {
+    const content = document.querySelector('.mat-drawer-content');
+
+    if (content) {
+      content.scrollTop = 0;
+    }
   }
 
   get operatorName() {


### PR DESCRIPTION
Selecting operators from left nav was not scrolling back to the top of container making it a little frustrating to browse. This updates the scroll position so you will always start at the top of the documentation for each operator.

On a side note, I think we should also consider adding a default route for the first operator (right now, `combineAll`) if the user navigates to the page without a selection.