### PR TITLE
fix(operators): hide related operators heading when empty

### DIFF
--- a/src/app/operators/components/operator-examples/operator-examples.component.scss
+++ b/src/app/operators/components/operator-examples/operator-examples.component.scss
@@ -33,10 +33,14 @@
   }
 }
 
+.code-example {
+  margin-bottom: 16px;
+}
+
 .bin-wrapper {
   iframe {
     border: none;
-    width:100%;
+    width: 100%;
     height: 350px;
   }
 }

--- a/src/app/operators/components/related-operators/related-operators.component.html
+++ b/src/app/operators/components/related-operators/related-operators.component.html
@@ -1,4 +1,5 @@
-<h2 class="related-operators"> Related Operators </h2>
+<h2 class="related-operators"
+    *ngIf="relatedOperators?.length"> Related Operators </h2>
 <ul class="section-list">
   <li *ngFor="let related of relatedOperators">
     <a [routerLink]="['/operators', related]"> {{ related }} </a>


### PR DESCRIPTION
This fixes two small cosmetic issues within the operators page.

1. Hides related operators heading when no related operators exist.
2. Provides some spacing between examples when multiple examples exist.