### PR TITLE
Added alt text to two images

### DIFF
--- a/src/app/core/components/toolbar/toolbar.component.html
+++ b/src/app/core/components/toolbar/toolbar.component.html
@@ -8,7 +8,7 @@
   <span class="title" fxFlex> WARNING: This is BETA site </span>
   <a aria-label="GitHub Repository" class="mat-button" href="https://github.com/ReactiveX" aria-disabled="false">
     <span class="mat-button-wrapper">
-      <img src="../../../assets/img/GitHub-Mark-Light-64px.png"> GitHub
+      <img src="../../../assets/img/GitHub-Mark-Light-64px.png" alt="ReactiveX GitHub Repository"> GitHub
     </span>
   </a>
 </mat-toolbar>

--- a/src/app/operators/components/marble-diagram/marble-diagram.component.html
+++ b/src/app/operators/components/marble-diagram/marble-diagram.component.html
@@ -1,7 +1,8 @@
 <div class="marble-wrapper mat-elevation-z2">
   <img class="marble-diagram"
        [src]="url"
-       *ngIf="url" />
+       *ngIf="url"
+       alt="Diagram of how {{operatorName}} works" />
 </div>
 <!-- <rx-marbles *ngIf="useInteractiveMarbles"
             [attr.key]="operatorName">


### PR DESCRIPTION
I added alt text to the GitHub logo in the header and the combineAll operator image that could possibly change.

I attempted to do this once but something was caught up in the Travis build, the link is below.
https://github.com/ReactiveX/rxjs-docs/pull/197