### PR TITLE
fix(operators): disable esc key closing of nested operator sidenav

### DIFF
--- a/src/app/operators/operators.component.html
+++ b/src/app/operators/operators.component.html
@@ -3,6 +3,7 @@
                [opened]="!smallScreen"
                [fixedTopGap]="operatorMenuGap"
                [fixedInViewport]="true"
+               [disableClose]="!smallScreen"
                class="operator-list-sidenav"
                #operatorSidenav>
     <mat-nav-list *ngFor="let category of categories"


### PR DESCRIPTION
Only disables close via esc when larger than a small screen

Closes Issue #255 Bug: Escape closes Sidebar