### PR TITLE
feat(docs): Enable only rxjs specific filter options on api docs

### DIFF
--- a/docs_app/src/app/custom-elements/api/api-list.component.html
+++ b/docs_app/src/app/custom-elements/api/api-list.component.html
@@ -7,11 +7,11 @@
               label="Type:">
   </aio-select>
 
-  <aio-select (change)="setStatus($event.option)"
+  <!-- <aio-select (change)="setStatus($event.option)"
               [options]="statuses"
               [selected]="status"
               label="Status:">
-  </aio-select>
+  </aio-select> -->
 
   <div class="form-search">
     <input #filter placeholder="Filter" (input)="setQuery($event.target.value)">

--- a/docs_app/src/app/custom-elements/api/api-list.component.ts
+++ b/docs_app/src/app/custom-elements/api/api-list.component.ts
@@ -43,21 +43,18 @@ export class ApiListComponent implements OnInit {
     { value: 'all', title: 'All' },
     { value: 'class', title: 'Class' },
     { value: 'const', title: 'Const'},
-    { value: 'decorator', title: 'Decorator' },
-    { value: 'directive', title: 'Directive' },
     { value: 'enum', title: 'Enum' },
     { value: 'function', title: 'Function' },
     { value: 'interface', title: 'Interface' },
-    { value: 'pipe', title: 'Pipe'},
     { value: 'type-alias', title: 'Type Alias' }
   ];
 
   statuses: Option[] = [
-    { value: 'all', title: 'All' },
-    { value: 'stable', title: 'Stable' },
-    { value: 'deprecated', title: 'Deprecated' },
-    { value: 'experimental', title: 'Experimental' },
-    { value: 'security-risk', title: 'Security Risk' }
+    // { value: 'all', title: 'All' },
+    // { value: 'stable', title: 'Stable' },
+    // { value: 'deprecated', title: 'Deprecated' },
+    // { value: 'experimental', title: 'Experimental' },
+    // { value: 'security-risk', title: 'Security Risk' }
   ];
 
   @ViewChild('filter') queryEl: ElementRef;
@@ -149,7 +146,7 @@ export class ApiListComponent implements OnInit {
 
     this.searchCriteria = {
       query: q,
-      status: this.status.value,
+      status: this.status ? this.status.value : 'all',
       type: this.type.value
     };
 


### PR DESCRIPTION
- On api docs, the filters were specific angular like directive, pipe, etc.,
  Now these filters have only rxjs specific options
- Status filter has been disabled until formalize the strategy for code statuses